### PR TITLE
Move dependency from python 3.9 to 3.7

### DIFF
--- a/.github/workflows/publish-to-test-pypi.yml
+++ b/.github/workflows/publish-to-test-pypi.yml
@@ -9,10 +9,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@master
-    - name: 🐍 Set up Python 3.9
+    - name: 🐍 Set up Python 3.7
       uses: actions/setup-python@v3
       with:
-        python-version: "3.9"
+        python-version: "3.7"
     - name: 🛠 Install dev requirements
       run: >-
         python -m

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,13 +4,13 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "aws_cron_expression_validator"
-version = "1.0.6"
+version = "1.0.7"
 authors = [
   { name="Graham Coster", email="bitjugglers@gmail.com" },
 ]
 description = "ValidatesAWS EventBridge cron expressions, which are similar to, but not compatible with Unix style cron expressions"
 readme = "README.md"
-requires-python = ">=3.09"
+requires-python = ">=3.7"
 classifiers = [
     "Development Status :: 5 - Production/Stable", # Chose either "3 - Alpha", "4 - Beta" or "5 - Production/Stable" as the current state of your package
     "Programming Language :: Python :: 3",


### PR DESCRIPTION
[torybenya asked if the python 3.9 dependency could be moved back to 3.8](
https://github.com/grumBit/aws_cron_expression_validator/issues/1#issuecomment-1265588982). 3.7 is currently the oldest supported version of Python and the CI/CD tests ran fine with Python 3.7, so moving back to that for anyone who may need it.