### PR TITLE
Fix year checking

### DIFF
--- a/aws_cron_expression_validator.code-workspace
+++ b/aws_cron_expression_validator.code-workspace
@@ -1,10 +1,10 @@
 {
-	"folders": [
-		{
-			"path": "."
-		},
-	],
-	"settings": {
-		"python.dataScience.debugJustMyCode": false
-	}
+  "folders": [
+    {
+      "path": "."
+    }
+  ],
+  "settings": {
+    "python.linting.flake8Enabled": false
+  }
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "aws_cron_expression_validator"
-version = "1.1.2"
+version = "1.1.3"
 authors = [
   { name="Graham Coster", email="bitjugglers@gmail.com" },
 ]

--- a/src/aws_cron_expression_validator/validator.py
+++ b/src/aws_cron_expression_validator/validator.py
@@ -55,6 +55,7 @@ class AWSCronExpressionValidator:
     day_of_week_values = r"([1-7]|SUN|MON|TUE|WED|THU|FRI|SAT)"  # 1-7 or SAT-SUN
     day_of_week_hash = rf"({day_of_week_values}#[1-5])"  # Day of the week in the Nth week of the month
     year_values = r"((19[7-9][0-9])|(2[0-1][0-9][0-9]))"  # 1970-2199
+    natural_number = r"([0-9]*[1-9][0-9]*)"  # Integers greater than 0
 
     @classmethod
     def validate(cls, expression: str) -> str:
@@ -100,8 +101,8 @@ class AWSCronExpressionValidator:
     @classmethod
     def slash_regex(cls, values: str) -> str:
         range_ = cls.range_regex(values)
-        return rf"((\*|{range_}|{values})\/[0-9]*[1-9][0-9]*)"
-        # Slash can be preceded by *, range, or a valid value and must be followed by an natural
+        return rf"((\*|{range_}|{values})\/{cls.natural_number})"
+        # Slash can be preceded by *, range, or a valid value and must be followed by a natural
         # number as the increment.
 
     @classmethod
@@ -132,4 +133,4 @@ class AWSCronExpressionValidator:
 
     @classmethod
     def year_regex(cls):
-        return rf"^({cls.common_regex(cls.year_values)}|\?|L)$"  # values , - * /
+        return rf"^({cls.common_regex(cls.year_values)})$"  # values , - * /

--- a/tests/aws_cron_expression_validator/test_validator.py
+++ b/tests/aws_cron_expression_validator/test_validator.py
@@ -71,7 +71,7 @@ class TestAWSCronExpressionValidator(TestCase):
         given_regex = validator.AWSCronExpressionValidator.minute_regex()
 
         given_valid_matches = ["*", "0", "1", "01", "10", "59"]
-        given_invalid_matches = ["60", "600", "-1", ""]
+        given_invalid_matches = ["60", "600", "-1", "", "?", "L", "W", "#"]
 
         self._then_matches(given_regex, given_valid_matches)
         self._then_does_not_match(given_regex, given_invalid_matches)
@@ -79,7 +79,7 @@ class TestAWSCronExpressionValidator(TestCase):
     def test_hour_regex(self):
         given_regex = validator.AWSCronExpressionValidator.hour_regex()
         given_valid_matches = ["*", "0", "1", "01", "10", "23"]
-        given_invalid_matches = ["24", "600", "001", "-1"]
+        given_invalid_matches = ["24", "600", "001", "-1", "?", "L", "W", "#"]
         self._then_matches(given_regex, given_valid_matches)
         self._then_does_not_match(given_regex, given_invalid_matches)
 
@@ -103,6 +103,7 @@ class TestAWSCronExpressionValidator(TestCase):
             "*/8W",
             "?W",
             "",
+            "#",
         ]
 
         self._then_matches(given_regex, given_valid_matches)
@@ -112,7 +113,7 @@ class TestAWSCronExpressionValidator(TestCase):
         given_regex = validator.AWSCronExpressionValidator.month_regex()
 
         given_valid_matches = ["*", "1", "01", "10", "12", "JAN", "FEB", "DEC", "JAN-MAR", "02-MAR", "*-MAR", "FEB/2"]
-        given_invalid_matches = ["0", "13", "600", "-1", "XZY", "JANUARY", "", "2/FEB"]
+        given_invalid_matches = ["0", "13", "600", "-1", "XZY", "JANUARY", "", "2/FEB", "?", "L", "W", "#"]
 
         self._then_matches(given_regex, given_valid_matches)
         self._then_does_not_match(given_regex, given_invalid_matches)
@@ -148,6 +149,7 @@ class TestAWSCronExpressionValidator(TestCase):
             "3#2,5#3",
             "3#2-4#2",
             "",
+            "W",
         ]
         self._then_matches(given_regex, given_valid_matches)
         self._then_does_not_match(given_regex, given_invalid_matches)
@@ -156,7 +158,22 @@ class TestAWSCronExpressionValidator(TestCase):
         given_regex = validator.AWSCronExpressionValidator.year_regex()
 
         given_valid_matches = ["*", "1970", "2199", "2022", "1992"]
-        given_invalid_matches = ["1969", "2200", "2222", "1111", "20221", "0", "1", "", "*1970", "19*70"]
+        given_invalid_matches = [
+            "1969",
+            "2200",
+            "2222",
+            "1111",
+            "20221",
+            "0",
+            "1",
+            "",
+            "*1970",
+            "19*70",
+            "?",
+            "L",
+            "W",
+            "#",
+        ]
 
         self._then_matches(given_regex, given_valid_matches)
         self._then_does_not_match(given_regex, given_invalid_matches)


### PR DESCRIPTION
### Description

The year checking was incorrectly allowing `?` and `L'.

### Changes
- Fixed year checking. 
- Added tests for similar bugs in all fields
- For clarity, factored out natural number regex 

### Issues

closes #7 
