### PR TITLE
Allow list of slash patterns as a valid pattern

### DIFF
--- a/src/aws_cron_expression_validator/validator.py
+++ b/src/aws_cron_expression_validator/validator.py
@@ -101,7 +101,6 @@ class AWSCronExpressionValidator:
     @classmethod
     def slash_regex(cls, values: str) -> str:
         range_ = cls.range_regex(values)
-        # return rf"((\*|{range_}|{values})\/{cls.natural_number})" # OG
         return rf"((\*|{range_}|{values})\/{cls.natural_number}\,?)+"
         # Slash can be preceded by *, range, or a valid value and must be followed by a natural
         # number as the increment.

--- a/src/aws_cron_expression_validator/validator.py
+++ b/src/aws_cron_expression_validator/validator.py
@@ -101,9 +101,12 @@ class AWSCronExpressionValidator:
     @classmethod
     def slash_regex(cls, values: str) -> str:
         range_ = cls.range_regex(values)
-        return rf"((\*|{range_}|{values})\/{cls.natural_number})"
+        # return rf"((\*|{range_}|{values})\/{cls.natural_number})" # OG
+        return rf"((\*|{range_}|{values})\/{cls.natural_number}\,?)+"
         # Slash can be preceded by *, range, or a valid value and must be followed by a natural
         # number as the increment.
+        # List of slash pattern allowed, e.g. hours 1-7/2,11-23/2 means
+        # "every two hours between 1am and 7am, plus every two hours between 11am and 11pm."
 
     @classmethod
     def common_regex(cls, values: str) -> str:

--- a/tests/aws_cron_expression_validator/test_validator.py
+++ b/tests/aws_cron_expression_validator/test_validator.py
@@ -23,7 +23,7 @@ class TestAWSCronExpressionValidator(TestCase):
     def test_slash_regex(self):
         minute_values = r"(0?[0-9]|[1-5][0-9])"  # [0]0-59
         given_regex = validator.AWSCronExpressionValidator.slash_regex(minute_values)
-        given_valid_matches = ["*/10", "1/10", "0/05", "0/15", "0/30", "55/1"]
+        given_valid_matches = ["*/10", "1/10", "0/05", "0/15", "0/30", "55/1", "1-7/2", "1-7/2,11-23/2", "*/10,*/3"]
         given_invalid_matches = [
             "",
             "/",
@@ -215,6 +215,7 @@ class TestAWSCronExpressionValidator(TestCase):
             "0 11-23/4 ? * 2-6 *",
             "0 11-23/2 * * ? *",
             "0 0 1 1-12/3 ? *",
+            "0 1-7/2,11-23/2 * * ? *"
         ]
 
         invalid_expression_exceptions = [


### PR DESCRIPTION
### Description

Currently, it's a valid pattern to chain slash patterns together, for example

- ``1-12/2,13-23/3 # hours`` represents "every second hour from 1am-12pm, every three hours 1pm-11pm".
- ``15/2,30/5 # minute`` represents "every second minute from the 15th minute, and every fifth minute from the 30th"
- ``*/2,*/10 # minute`` represents "every second minute, and every tenth minute"

However, as #13 mentions, these will currently fail validation. This PR updates the logic to allow these patterns.

### Changes

Expands slash pattern logic to allow chains of slashes. Relevant unit tests updated.

### Issues

closes #13 
