### PR TITLE
Allow LW in day of month. Allow mixed case for months and days.

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,14 +13,16 @@
 
 Validates these [AWS EventBridge cron expressions](https://docs.aws.amazon.com/eventbridge/latest/userguide/eb-create-rule-schedule.html#eb-cron-expressions), which are similar to, but not compatible with Unix style cron expressions;
 
-| Field        | Values          | Wildcards     |
-| :----------: | :-------------: | :-----------: |
-| Minute       | 0-59            | , - * /       |
-| Hour         | 0-23            | , - * /       |
-| Day-of-month | 1-31            | , - * ? / L W |
-| Month        | 1-12 or JAN-DEC | , - * /       |
-| Day-of-week  |  1-7 or SUN-SAT | , - * ? L #   |
-| Year         | 1970-2199       | , - * /       |
+| Field        | Values          | Wildcards      |
+| :----------- | :-------------- | :------------- |
+| Minute       | 0-59            | , - \* /       |
+| Hour         | 0-23            | , - \* /       |
+| Day-of-month | 1-31            | , - \* ? / L W |
+| Month        | 1-12 or JAN-DEC | , - \* /       |
+| Day-of-week  | 1-7 or SUN-SAT  | , - \* ? L #   |
+| Year         | 1970-2199       | , - \* /       |
+
+_NB: It appears AWS is supporting the Quartz Job Scheduler cron expressions. More details than AWS provides is available in the [Cron Trigger Tutorial](http://www.quartz-scheduler.org/documentation/quartz-2.3.0/tutorials/crontrigger.html)._
 
 This was inspired by Niloy Chakraborty's [AWSCronValidator.py](https://gist.github.com/ultrasonex/e1fdb8354408a56df91aa4902d17aa6a) project.
 

--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -1,5 +1,10 @@
 # Release History
 
+### v1.1.10 [2024-02-01]
+
+- Fixes;
+  - [Doesn't allow LW in day of month, or mixed case for months and days](https://github.com/grumBit/aws_cron_expression_validator/issues/18)
+
 ### v1.1.9 [2024-02-01]
 
 - Fixes;

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "aws_cron_expression_validator"
-version = "1.1.9"
+version = "1.1.10"
 authors = [
   { name="Graham Coster", email="bitjugglers@gmail.com" },
 ]

--- a/src/aws_cron_expression_validator/validator.py
+++ b/src/aws_cron_expression_validator/validator.py
@@ -51,8 +51,8 @@ class AWSCronExpressionValidator:
     minute_values = r"(0?[0-9]|[1-5][0-9])"  # [0]0-59
     hour_values = r"(0?[0-9]|1[0-9]|2[0-3])"  # [0]0-23
     month_of_day_values = r"(0?[1-9]|[1-2][0-9]|3[0-1])"  # [0]1-31
-    month_values = r"(0?[1-9]|1[0-2]|JAN|FEB|MAR|APR|MAY|JUN|JUL|AUG|SEP|OCT|NOV|DEC)"  # [0]1-12 or JAN-DEC
-    day_of_week_values = r"([1-7]|SUN|MON|TUE|WED|THU|FRI|SAT)"  # 1-7 or SAT-SUN
+    month_values = r"(?i)(0?[1-9]|1[0-2]|JAN|FEB|MAR|APR|MAY|JUN|JUL|AUG|SEP|OCT|NOV|DEC)"  # [0]1-12 or JAN-DEC
+    day_of_week_values = r"(?i)([1-7]|SUN|MON|TUE|WED|THU|FRI|SAT)"  # 1-7 or SAT-SUN
     day_of_week_hash = rf"({day_of_week_values}#[1-5])"  # Day of the week in the Nth week of the month
     year_values = r"((19[7-9][0-9])|(2[0-1][0-9][0-9]))"  # 1970-2199
     natural_number = r"([0-9]*[1-9][0-9]*)"  # Integers greater than 0
@@ -126,7 +126,8 @@ class AWSCronExpressionValidator:
     @classmethod
     def day_of_month_regex(cls) -> str:
         return (
-            rf"^({cls.common_regex(cls.month_of_day_values)}|\?|L|{cls.month_of_day_values}W)$"  # values , - * / ? L W
+            rf"^({cls.common_regex(cls.month_of_day_values)}|\?|L|LW|{cls.month_of_day_values}W)$"
+            # values , - * / ? L W
         )
 
     @classmethod

--- a/tests/aws_cron_expression_validator/test_validator.py
+++ b/tests/aws_cron_expression_validator/test_validator.py
@@ -94,7 +94,7 @@ class TestAWSCronExpressionValidator(TestCase):
 
     def test_day_of_month_regex(self):
         given_regex = validator.AWSCronExpressionValidator.day_of_month_regex()
-        given_valid_matches = ["*", "1", "01", "10", "23", "31", "?", "L", "1W", "31W", "11W"]
+        given_valid_matches = ["*", "1", "01", "10", "23", "31", "?", "L", "1W", "31W", "11W", "LW"]
         given_invalid_matches = [
             "0",
             "32",
@@ -121,7 +121,7 @@ class TestAWSCronExpressionValidator(TestCase):
     def test_month_regex(self):
         given_regex = validator.AWSCronExpressionValidator.month_regex()
 
-        given_valid_matches = ["*", "1", "01", "10", "12", "JAN", "FEB", "DEC", "JAN-MAR", "02-MAR", "*-MAR", "FEB/2"]
+        given_valid_matches = ["*", "1", "01", "10", "12", "JAN", "feb", "DeC", "JAN-MAR", "02-MAR", "*-MAR", "FEB/2"]
         given_invalid_matches = ["0", "13", "600", "-1", "XZY", "JANUARY", "", "2/FEB", "?", "L", "W", "#"]
 
         self._then_matches(given_regex, given_valid_matches)
@@ -129,7 +129,7 @@ class TestAWSCronExpressionValidator(TestCase):
 
     def test_day_of_week_regex(self):
         given_regex = validator.AWSCronExpressionValidator.day_of_week_regex()
-        given_valid_matches = ["*", "1", "5", "7", "MON", "?", "L", "5L", "MONL", "3#2", "MON-FRI", "L-1", "L-7"]
+        given_valid_matches = ["*", "1", "5", "7", "MON", "?", "L", "5L", "monL", "3#2", "MON-FRI", "L-1", "L-7"]
         given_invalid_matches = [
             "Monday",
             "0",
@@ -199,7 +199,7 @@ class TestAWSCronExpressionValidator(TestCase):
             "0 10 * * ? *",
             "15 12 * * ? *",
             "0 8 1 * ? *",
-            "1/5 8-17 ? * MON-FRI *",
+            "1/5 8-17 ? * Mon-Fri *",
             "0 9 ? * 2#1 *",
             "0 07/12 ? * * *",
             "10,20,30,40 07/12 ? * * *",


### PR DESCRIPTION
### Description

Allows;

- The `L` and `W` characters can also be combined in the day-of-month field to yield `LW`, which translates to *"last weekday of the month"*
- The legal characters and the names of months and days of the week are not case sensitive. `MON` is the same as `mOn`.


### Issues

closes #18
