### PR TITLE
Change regexp syntax to make ignoring case compatible with python 3.12

### DIFF
--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -1,5 +1,10 @@
 # Release History
 
+### v1.1.11 [2024-02-08]
+
+- Fixes;
+  - [Latest version 1.1.10 does not seem to work with Python 3.12](https://github.com/grumBit/aws_cron_expression_validator/issues/20)
+
 ### v1.1.10 [2024-02-01]
 
 - Fixes;

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "aws_cron_expression_validator"
-version = "1.1.10"
+version = "1.1.11"
 authors = [
   { name="Graham Coster", email="bitjugglers@gmail.com" },
 ]

--- a/src/aws_cron_expression_validator/validator.py
+++ b/src/aws_cron_expression_validator/validator.py
@@ -51,8 +51,8 @@ class AWSCronExpressionValidator:
     minute_values = r"(0?[0-9]|[1-5][0-9])"  # [0]0-59
     hour_values = r"(0?[0-9]|1[0-9]|2[0-3])"  # [0]0-23
     month_of_day_values = r"(0?[1-9]|[1-2][0-9]|3[0-1])"  # [0]1-31
-    month_values = r"(?i)(0?[1-9]|1[0-2]|JAN|FEB|MAR|APR|MAY|JUN|JUL|AUG|SEP|OCT|NOV|DEC)"  # [0]1-12 or JAN-DEC
-    day_of_week_values = r"(?i)([1-7]|SUN|MON|TUE|WED|THU|FRI|SAT)"  # 1-7 or SAT-SUN
+    month_values = r"(?i:0?[1-9]|1[0-2]|JAN|FEB|MAR|APR|MAY|JUN|JUL|AUG|SEP|OCT|NOV|DEC)"  # [0]1-12 or JAN-DEC
+    day_of_week_values = r"(?i:[1-7]|SUN|MON|TUE|WED|THU|FRI|SAT)"  # 1-7 or SAT-SUN
     day_of_week_hash = rf"({day_of_week_values}#[1-5])"  # Day of the week in the Nth week of the month
     year_values = r"((19[7-9][0-9])|(2[0-1][0-9][0-9]))"  # 1970-2199
     natural_number = r"([0-9]*[1-9][0-9]*)"  # Integers greater than 0


### PR DESCRIPTION
### Description

Change regexp syntax to make ignoring case compatible with python 3.12

### Issues

closes #20
