### PR TITLE
Remove stale Snyk Advisor package health reporting

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,6 @@
 [![GitHub license](https://img.shields.io/github/license/grumbit/aws_cron_expression_validator)](https://github.com/grumbit/aws_cron_expression_validator/blob/master/LICENSE)
 [![GitHub forks](https://img.shields.io/github/forks/grumbit/aws_cron_expression_validator)](https://github.com/grumbit/aws_cron_expression_validator/network)
 [![GitHub stars](https://img.shields.io/github/stars/grumbit/aws_cron_expression_validator)](https://github.com/grumbit/aws_cron_expression_validator/stargazers)
-[![Package health](https://snyk.io/advisor/python/aws-cron-expression-validator/badge.svg)](https://snyk.io/advisor/python/aws-cron-expression-validator)
 
 # AWSCronExpressionValidator
 

--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -1,5 +1,10 @@
 # Release History
 
+### v1.1.12 [2024-02-08]
+
+- Documentation change only;
+  - Remove stale Snyk advisor package health reporting
+
 ### v1.1.11 [2024-02-08]
 
 - Fixes;

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "aws_cron_expression_validator"
-version = "1.1.11"
+version = "1.1.12"
 authors = [
   { name="Graham Coster", email="bitjugglers@gmail.com" },
 ]


### PR DESCRIPTION
Snyk Advisor is using installs per week data that is out of date, which means the package health is lower than it should be. According to Snyk, this package hasn't been installed by anyone in the past 5 months, while github is showing hundreds per week.
